### PR TITLE
Update Chinese translations and replace 'CLEAR' text to translation function

### DIFF
--- a/locales/zh_CN/translation.json
+++ b/locales/zh_CN/translation.json
@@ -1,7 +1,7 @@
 {
   "layoutSelection": {
     "headerImage": "/images/choose-your-fighter.svg",
-    "headerText": "选择是要使用扩展布局还是原始的经典布局。",
+    "headerText": "选择是要使用扩展布局还是原本的经典布局。",
     "bottomText": [
       "更多定制选项即将推出！如果您有好点子，或者想提前体验新功能，请加入我们的 ",
       "Discord",
@@ -9,7 +9,7 @@
     ]
   },
   "languageSelection": {
-    "headerText": ["注意!", " 调色板名称将根据所选语言进行更改。"],
+    "headerText": ["注意!", " 调色板名称将根据所选语言进行翻译。"],
     "bottomText": [
       "缺少您所使用的语言？不用担心，您可以帮忙添加您的语言的翻译！前往我们的 ",
       "Discord",
@@ -26,8 +26,8 @@
     "show": "显示"
   },
   "palettesModal": {
-    "modalName": "色板",
-    "description": "自定义您的建议",
+    "modalName": "色板列表",
+    "description": "选择启用的色板",
     "disableAll": "禁用全部",
     "enableAll": "启用全部"
   },

--- a/src/components/ImportModal.tsx
+++ b/src/components/ImportModal.tsx
@@ -96,7 +96,7 @@ export const ImportModal = (
             onClick={() => setContent("")}
             style={{marginRight: '0.4em'}}
           >
-            clear
+            {t("importModal.clear")}
           </Button>
           <Button round small primary onClick={() => onAccept(content)}>{t("importModal.accept")}</Button>
         </div>


### PR DESCRIPTION
The 'clear' button in import modal are still using static text 'clear', although it have a node  `importModal.clear` in translation files, this pr will fix it.
And I have updated some of Chinese translations to make it easier to understand.